### PR TITLE
Adds Android Network Permissions to App Manifest

### DIFF
--- a/TwilioMiniHack.Droid/Properties/AndroidManifest.xml
+++ b/TwilioMiniHack.Droid/Properties/AndroidManifest.xml
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.twilio.twiliominihack">
 	<uses-sdk android:minSdkVersion="21" />
+	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+	<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 	<application android:allowBackup="true" android:icon="@mipmap/icon" android:label="@string/app_name" android:theme="@android:style/Theme.Material.Light">
 	</application>
 </manifest>


### PR DESCRIPTION
The connections to the Twilio token server are denied without
including `Access Network State` and `Access WiFi State` permissions
